### PR TITLE
WPCS formatter: Minor change to the version number comment format.

### DIFF
--- a/src/Formatter/WPCS.php
+++ b/src/Formatter/WPCS.php
@@ -38,7 +38,7 @@ class WPCS implements Formatter {
 
 		foreach ( $results as $version => $functions ) {
 
-			$output .= "\n\t\t// {$version}\n";
+			$output .= "\n\t\t// WP {$version}.\n";
 
 			ksort( $functions, SORT_STRING | SORT_FLAG_CASE );
 


### PR DESCRIPTION
Was: `// x.x.x`
Now: `// WP x.x.x.`

To eliminate as much noise as possible in the comparison, I've started adding the version nr comments to the array in the WPCS sniff as well.

For the comments to pass the `WordPress-Docs` sniffing, they need to end in a period.
What with just having a number + period looking a bit off, adding the `WP` makes it a little more phrase like.