### PR TITLE
Fix "array to string"conversion error

### DIFF
--- a/src/Formatter/Markdown.php
+++ b/src/Formatter/Markdown.php
@@ -50,7 +50,7 @@ class Markdown implements Formatter {
 
 				ksort( $functions );
 
-				$functions = array_unique( $functions );
+				$functions = array_unique( $functions, SORT_REGULAR );
 
 				foreach ( $functions as $function => $data ) {
 


### PR DESCRIPTION
The default for `array_unique()` is `SORT_STRING`, but as the `$data` values in `$functions` are arrays, this causes a `PHP Notice:  Array to string conversion` notice and potentially loss of data.