### PR TITLE
Fix unit test failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_script:
     - composer install
     - >
       if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." || $TRAVIS_PHP_VERSION == nightly ]]; then
-        export PATH="$HOME/.composer/vendor/bin:$PATH"
-        composer global require "phpunit/phpunit=^5.7.15"
+        export PATH="$(pwd)/vendor/bin:$PATH"
+        composer require "phpunit/phpunit=^5.7.15" --no-suggest --no-scripts
       fi
 
 script:


### PR DESCRIPTION
Looks like Travis made some changes to the images causing the `global` install of PHPUnit to no longer be found correctly.

This changes the PHPUnit install to a local one making it less dependent on the Travis image directory structure.